### PR TITLE
Compare itch execution prices with simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ summary = engine.generate_scaled_data()
 ```
 Then generate plots with step (2).
 
+### 5) ITCH comparison (per-second execution alignment)
+
+```bash
+# Compare simulated executions with NASDAQ ITCH trade prices aggregated per second
+python src/itch_compare.py \
+  --db quick_test_orderbook.db \
+  --symbol AAPL \
+  --itch /path/to/itch_trades_AAPL.csv \
+  --outdir itch_compare_out/AAPL \
+  --agg last   # options: last, vwap, median
+```
+
+Outputs in `--outdir`:
+- `itch_compare_<SYMBOL>.csv`: per-execution alignment with ITCH per-second price and error in bps
+- `metrics_<SYMBOL>.json`: summary metrics (mean/median abs error bps, p95, bias, coverage)
+- `itch_vs_sim_<SYMBOL>.png`: ITCH per-second series overlaid with sim executions
+
+Notes:
+- ITCH loader expects a CSV with columns including `timestamp`, `symbol`, `price` (and optional `size`). Timestamps are converted to UTC; naive timestamps are localized to `America/New_York` by default.
+- For raw binary ITCH, convert to CSV first or implement the stub in `src/itch_ingestion.py`.
+
 ## ✅ What’s Calibrated and Why It Matters
 
 - **Order sizes**: Lognormal per agent type → realistic heavy tails

--- a/src/itch_compare.py
+++ b/src/itch_compare.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+ITCH vs Simulation Execution Comparison (Per-Second)
+====================================================
+
+Compare simulated execution prices against NASDAQ ITCH trade data aggregated to
+per-second windows. Outputs a CSV of aligned executions and summary metrics,
+and optionally a plot overlaying ITCH per-second prices with simulation fills.
+
+Usage
+-----
+python src/itch_compare.py \
+  --db path/to/sim.db \
+  --symbol AAPL \
+  --itch path/to/itch_trades.csv \
+  --outdir out/itch_compare/AAPL \
+  --agg last  # or vwap, median
+
+Note: Ensure your PYTHONPATH includes 'src' if importing from modules here.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Any, Optional
+from datetime import datetime
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+from itch_ingestion import ITCHLoadConfig, load_itch_trades, aggregate_trades_to_seconds
+
+# Reuse DB loaders from validation_viz to keep schema compatibility
+from validation_viz import load_simulated_frames
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _normalize_sim_trades(trades: pd.DataFrame) -> pd.DataFrame:
+    if trades is None or trades.empty:
+        return pd.DataFrame(columns=["timestamp", "price", "quantity", "side", "aggressor_side"]) 
+    df = trades.copy()
+    # Standardize timestamp
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    df = df.dropna(subset=["timestamp"])  # keep executed rows only
+    # Ensure price present
+    if "price" not in df.columns:
+        raise ValueError("Simulation trades must include 'price'")
+    # Quantity optional but helpful
+    if "quantity" not in df.columns:
+        df["quantity"] = np.nan
+    # Side mapping
+    if "aggressor_side" not in df.columns:
+        if "side" not in df.columns:
+            df["aggressor_side"] = "UNK"
+        else:
+            df["aggressor_side"] = df["side"].astype(str)
+    else:
+        df["aggressor_side"] = df["aggressor_side"].astype(str)
+    return df[["timestamp", "price", "quantity", "aggressor_side"]].rename(columns={"aggressor_side": "side"})
+
+
+def _compute_metrics(aligned: pd.DataFrame) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    if aligned is None or aligned.empty:
+        return {"error": "No comparable data"}
+    if "price_error_bps" not in aligned.columns:
+        return {"error": "No error column"}
+    err = aligned["price_error_bps"].replace([np.inf, -np.inf], np.nan).dropna()
+    if err.empty:
+        return {"error": "No comparable data"}
+    out["count"] = int(len(err))
+    out["coverage_ratio"] = float(len(err) / len(aligned)) if len(aligned) else 0.0
+    out["mean_abs_error_bps"] = float(err.abs().mean())
+    out["median_abs_error_bps"] = float(err.abs().median())
+    out["p95_abs_error_bps"] = float(err.abs().quantile(0.95))
+    out["bias_bps"] = float(err.mean())
+    # Optional side-conditioned metrics
+    if "side" in aligned.columns:
+        for side_val, grp in aligned.dropna(subset=["price_error_bps"]).groupby("side"):
+            gerr = grp["price_error_bps"].dropna()
+            if not gerr.empty:
+                out[f"{side_val}_mean_abs_bps"] = float(gerr.abs().mean())
+                out[f"{side_val}_bias_bps"] = float(gerr.mean())
+    return out
+
+
+def compare_sim_to_itch(
+    db_path: str,
+    symbol: str,
+    itch_path: str,
+    outdir: str,
+    agg: str = "last",
+    include_plot: bool = True,
+) -> Dict[str, Any]:
+    out_path = Path(outdir)
+    _ensure_outdir(out_path)
+
+    # Load simulation frames
+    frames = load_simulated_frames(db_path, symbol)
+    sim_trades = _normalize_sim_trades(frames.get("trades", pd.DataFrame()))
+
+    # Load and aggregate ITCH trades
+    cfg = ITCHLoadConfig(path=itch_path, symbol=symbol, fmt="csv")
+    itch_trades = load_itch_trades(cfg)
+    itch_sec = aggregate_trades_to_seconds(itch_trades, agg=agg)
+
+    if sim_trades.empty or itch_sec.empty:
+        aligned = pd.DataFrame()
+        metrics = {"error": "Missing data", "sim_trades": len(sim_trades), "itch_seconds": len(itch_sec)}
+    else:
+        # Round to second for matching
+        st = sim_trades.copy()
+        st["sec"] = st["timestamp"].dt.floor("1s")
+        it = itch_sec.rename(columns={"timestamp": "sec", "price": "itch_price"})
+        # Align simulated executions to ITCH per second (left join to keep all sim fills)
+        aligned = pd.merge(
+            st,
+            it,
+            on="sec",
+            how="left",
+        )
+        # Compute error in bps
+        if "itch_price" in aligned.columns:
+            aligned["price_error_bps"] = (
+                (aligned["price"] - aligned["itch_price"]) / aligned["itch_price"] * 10000.0
+            )
+        metrics = _compute_metrics(aligned)
+
+    # Save outputs
+    comp_csv = out_path / f"itch_compare_{symbol}.csv"
+    aligned_cols = [
+        c for c in ["timestamp", "sec", "price", "quantity", "side", "itch_price", "price_error_bps"]
+        if c in (aligned.columns if not aligned.empty else [])
+    ]
+    if not aligned.empty:
+        aligned[aligned_cols].to_csv(comp_csv, index=False)
+
+    # Plot overlay: ITCH per-second series vs sim execution scatter
+    if include_plot and not aligned.empty and not itch_sec.empty:
+        fig, ax = plt.subplots(figsize=(12, 5))
+        # ITCH line
+        ax.plot(itch_sec["timestamp"], itch_sec["price"], label=f"ITCH {symbol} (per-sec {agg})", alpha=0.8)
+        # Sim executions
+        colors = aligned["side"].map({"BUY": "tab:green", "SELL": "tab:red"}).fillna("tab:blue")
+        sizes = aligned.get("quantity", pd.Series([100] * len(aligned))).astype(float).pow(0.5)
+        sizes = (sizes / (sizes.max() if sizes.max() else 1.0) * 40.0) + 12.0
+        ax.scatter(aligned["timestamp"], aligned["price"], c=colors, s=sizes, alpha=0.6, label="Sim executions")
+        ax.set_title(f"{symbol}: ITCH per-second vs Sim Executions")
+        ax.set_xlabel("Time (UTC)")
+        ax.set_ylabel("Price")
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(out_path / f"itch_vs_sim_{symbol}.png", dpi=120)
+        plt.close(fig)
+
+    # Save metrics
+    import json
+    with open(out_path / f"metrics_{symbol}.json", "w") as f:
+        json.dump({"symbol": symbol, "agg": agg, **metrics}, f, indent=2)
+
+    return {"aligned": aligned, "metrics": metrics, "itch_seconds": itch_sec}
+
+
+def main():
+    p = argparse.ArgumentParser(description="Compare sim executions vs ITCH per-second prices")
+    p.add_argument("--db", required=True, help="Path to simulation SQLite DB")
+    p.add_argument("--symbol", required=True, help="Symbol to analyze (e.g., AAPL)")
+    p.add_argument("--itch", required=True, help="Path to ITCH trades CSV")
+    p.add_argument("--outdir", default="itch_compare_out", help="Output directory")
+    p.add_argument("--agg", default="last", choices=["last", "vwap", "median"], help="Second-level aggregation for ITCH")
+    p.add_argument("--no-plot", action="store_true", help="Disable plots")
+    args = p.parse_args()
+
+    result = compare_sim_to_itch(
+        db_path=args.db,
+        symbol=args.symbol,
+        itch_path=args.itch,
+        outdir=args.outdir,
+        agg=args.agg,
+        include_plot=(not args.no_plot),
+    )
+    print("Comparison metrics:")
+    print(result["metrics"])  # simple stdout summary
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/itch_ingestion.py
+++ b/src/itch_ingestion.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+NASDAQ ITCH Ingestion Utilities
+===============================
+
+Lightweight helpers to load NASDAQ ITCH trade data and aggregate it to
+per-second price series for comparison with simulated executions.
+
+Notes
+-----
+- This module prioritizes CSV ingestion of pre-parsed ITCH datasets to avoid
+  heavy binary parsers and external dependencies. If you have raw ITCH binary
+  files, convert them to CSV first (e.g., using vendor tools) or implement the
+  stubbed binary loader below.
+- Expected CSV columns (flexible):
+  - timestamp (or: time, ts, datetime, date/time parts)
+  - symbol (case-sensitive ticker)
+  - price (float, in dollars)
+  - shares or size (optional; for VWAP)
+  - type/event_type (optional; if present, rows should include trade events)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Any
+import pandas as pd
+import numpy as np
+
+
+@dataclass
+class ITCHLoadConfig:
+    path: str
+    symbol: Optional[str] = None
+    fmt: str = "csv"  # 'csv' | 'binary' (binary is stubbed)
+    tz_local: str = "America/New_York"  # ITCH timestamps are in exchange time
+    assume_local_naive: bool = True      # If timestamps have no tz, localize then convert to UTC
+    price_col: str = "price"
+    size_col: str = "size"
+    timestamp_col: Optional[str] = None  # If None, auto-detect
+    type_col: Optional[str] = None       # e.g., 'type' / 'event_type'
+    trade_type_values: Optional[set[str]] = None  # e.g., {'P','Q','TRADE'}; if None, do not filter
+
+
+def _coerce_timestamp_series(
+    s: pd.Series,
+    tz_local: str,
+    assume_local_naive: bool,
+) -> pd.Series:
+    """Coerce a timestamp-like Series into UTC-aware pandas Timestamps.
+
+    Handles common cases:
+    - ISO8601 strings
+    - Integer/float epoch in ns/us/ms/s
+    - Naive datetimes interpreted as tz_local if assume_local_naive
+    """
+    if pd.api.types.is_integer_dtype(s) or pd.api.types.is_float_dtype(s):
+        # Try to infer epoch unit by magnitude (do not force Int64 for floats)
+        numeric = s.dropna().astype(float)
+        maxv = float(numeric.max()) if not numeric.empty else 0.0
+        if maxv > 1e14:
+            # nanoseconds
+            ts = pd.to_datetime(s, unit="ns", utc=True, errors="coerce")
+        elif maxv > 1e11:
+            # milliseconds
+            ts = pd.to_datetime(s, unit="ms", utc=True, errors="coerce")
+        elif maxv > 1e9:
+            # seconds (with possible fractional part)
+            ts = pd.to_datetime(s, unit="s", utc=True, errors="coerce")
+        else:
+            # Likely seconds; if offset-from-midnight, this will be NaT
+            ts = pd.to_datetime(s, unit="s", utc=True, errors="coerce")
+        return ts
+
+    # String or datetime-like
+    ts = pd.to_datetime(s, utc=False, errors="coerce")
+    # If tz-naive and assume_local_naive, localize to exchange tz then convert to UTC
+    if assume_local_naive:
+        # If series is tz-naive, localize to exchange tz then convert to UTC
+        if getattr(ts.dt, "tz", None) is None:
+            try:
+                ts = ts.dt.tz_localize(tz_local).dt.tz_convert("UTC")
+            except Exception:
+                # If localization fails, try parsing with utc=True as fallback
+                ts = pd.to_datetime(s, utc=True, errors="coerce")
+        else:
+            # Series already has tz; convert to UTC
+            try:
+                ts = ts.dt.tz_convert("UTC")
+            except Exception:
+                ts = pd.to_datetime(s, utc=True, errors="coerce")
+    else:
+        # Assume incoming has tz info or is already UTC; if naive, coerce to UTC
+        try:
+            if getattr(ts.dt, "tz", None) is None:
+                ts = ts.dt.tz_localize("UTC")
+            else:
+                ts = ts.dt.tz_convert("UTC")
+        except Exception:
+            ts = pd.to_datetime(s, utc=True, errors="coerce")
+    return ts
+
+
+def _detect_timestamp_column(df: pd.DataFrame, hint: Optional[str]) -> Optional[str]:
+    if hint and hint in df.columns:
+        return hint
+    candidates = [
+        "timestamp", "ts", "time", "datetime", "date_time",
+        "Timestamp", "Time", "Datetime", "DateTime",
+    ]
+    for c in candidates:
+        if c in df.columns:
+            return c
+    # Try split date/time columns
+    if "date" in df.columns and ("time" in df.columns or "nanoseconds" in df.columns or "ns" in df.columns):
+        return None  # will be constructed
+    return None
+
+
+def _construct_timestamp_from_parts(df: pd.DataFrame, tz_local: str) -> Optional[pd.Series]:
+    """Construct timestamp from date + time/nanoseconds parts if present."""
+    if "date" in df.columns and "time" in df.columns:
+        try:
+            dt = pd.to_datetime(df["date"].astype(str) + " " + df["time"].astype(str), errors="coerce")
+            dt = dt.dt.tz_localize(tz_local).dt.tz_convert("UTC")
+            return dt
+        except Exception:
+            pass
+    # ITCH often uses ns offset from midnight with a trading date
+    ns_col = None
+    for c in ("nanoseconds", "ns", "time_ns", "offset_ns"):
+        if c in df.columns:
+            ns_col = c
+            break
+    if ns_col is not None and "date" in df.columns:
+        try:
+            base = pd.to_datetime(df["date"].astype(str), errors="coerce")
+            base = base.dt.tz_localize(tz_local)
+            delta = pd.to_timedelta(df[ns_col].astype("Int64"), unit="ns")
+            dt = (base + delta).dt.tz_convert("UTC")
+            return dt
+        except Exception:
+            return None
+    return None
+
+
+def load_itch_trades_csv(cfg: ITCHLoadConfig) -> pd.DataFrame:
+    """Load ITCH trades from a CSV file and return a normalized DataFrame.
+
+    Columns in the returned frame:
+    - timestamp (UTC, tz-aware)
+    - symbol
+    - price (float)
+    - size (optional; float)
+    """
+    df = pd.read_csv(cfg.path)
+
+    # Normalize column names for flexible matching
+    original_columns: Dict[str, str] = {c: c for c in df.columns}
+    cols_lower = {c.lower(): c for c in df.columns}
+
+    # Determine timestamp
+    ts_col = _detect_timestamp_column(df, cfg.timestamp_col)
+    if ts_col is None:
+        ts_series = _construct_timestamp_from_parts(df, cfg.tz_local)
+        if ts_series is None:
+            # Try any numeric time-like column as epoch
+            for candidate in ("epoch", "ts", "time", "timestamp", "epochns", "epoch_ns"):
+                if candidate in df.columns:
+                    ts_series = _coerce_timestamp_series(df[candidate], cfg.tz_local, cfg.assume_local_naive)
+                    break
+        if ts_series is None:
+            raise ValueError("Could not detect/construct timestamp from CSV. Provide timestamp_col in config.")
+        df["timestamp"] = ts_series
+    else:
+        df["timestamp"] = _coerce_timestamp_series(df[ts_col], cfg.tz_local, cfg.assume_local_naive)
+
+    # Price column
+    price_col = cfg.price_col if cfg.price_col in df.columns else None
+    if price_col is None:
+        for c in ("price", "trade_price", "px", "Price", "PRICE"):
+            if c in df.columns:
+                price_col = c
+                break
+    if price_col is None:
+        raise ValueError("No price column found in ITCH CSV")
+    df["price"] = df[price_col].astype(float)
+
+    # Size/volume
+    size_col = cfg.size_col if cfg.size_col in df.columns else None
+    if size_col is None:
+        for c in ("size", "shares", "quantity", "vol", "volume", "Size", "Shares"):
+            if c in df.columns:
+                size_col = c
+                break
+    if size_col is not None:
+        df["size"] = df[size_col].astype(float)
+    else:
+        df["size"] = np.nan
+
+    # Symbol
+    sym_col = None
+    for c in ("symbol", "Symbol", "ticker", "Ticker"):
+        if c in df.columns:
+            sym_col = c
+            break
+    if sym_col is None:
+        raise ValueError("No symbol column found in ITCH CSV")
+    df["symbol"] = df[sym_col].astype(str)
+
+    # Optional filtering by event type
+    if cfg.type_col and cfg.type_col in df.columns and cfg.trade_type_values:
+        df = df[df[cfg.type_col].astype(str).str.upper().isin({v.upper() for v in cfg.trade_type_values})]
+
+    # Filter symbol
+    if cfg.symbol is not None:
+        df = df[df["symbol"] == cfg.symbol]
+
+    # Keep only needed columns
+    out = df[["timestamp", "symbol", "price", "size"]].copy()
+    out = out.dropna(subset=["timestamp", "price"]).sort_values("timestamp")
+    return out
+
+
+def load_itch_trades_binary(cfg: ITCHLoadConfig) -> pd.DataFrame:
+    """Stub for raw ITCH binary loading.
+
+    For now, raise an informative error to encourage CSV usage.
+    """
+    raise NotImplementedError(
+        "Binary ITCH parsing is not implemented. Convert to CSV first or add a parser."
+    )
+
+
+def load_itch_trades(cfg: ITCHLoadConfig) -> pd.DataFrame:
+    if cfg.fmt.lower() == "csv":
+        return load_itch_trades_csv(cfg)
+    elif cfg.fmt.lower() in ("bin", "binary", "itch"):
+        return load_itch_trades_binary(cfg)
+    else:
+        raise ValueError(f"Unknown ITCH format: {cfg.fmt}")
+
+
+def aggregate_trades_to_seconds(
+    trades: pd.DataFrame,
+    agg: str = "last",  # 'last' | 'vwap' | 'median'
+    price_col: str = "price",
+    size_col: str = "size",
+) -> pd.DataFrame:
+    """Aggregate tick trades to per-second price series.
+
+    Returns a DataFrame with columns: timestamp, price
+    """
+    if trades is None or trades.empty:
+        return pd.DataFrame(columns=["timestamp", "price"]) 
+    df = trades.copy()
+    if "timestamp" not in df.columns:
+        raise ValueError("trades DataFrame must include 'timestamp'")
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    df = df.dropna(subset=["timestamp"]).sort_values("timestamp")
+    df["second"] = df["timestamp"].dt.floor("1s")
+
+    if agg == "last":
+        # Last trade price within each second
+        sec = df.groupby("second")[price_col].last().rename("price").reset_index()
+    elif agg == "vwap":
+        # Volume-weighted average price within each second
+        # Fallback to simple mean if size is missing
+        has_size = size_col in df.columns and df[size_col].notna().any()
+        if has_size:
+            tmp = df[["second", price_col, size_col]].copy()
+            tmp["wx"] = tmp[price_col] * tmp[size_col].astype(float)
+            agg_df = tmp.groupby("second")[ ["wx", size_col] ].sum(min_count=1)
+            sec = (agg_df["wx"] / agg_df[size_col]).rename("price").reset_index()
+        else:
+            sec = df.groupby("second")[price_col].mean().rename("price").reset_index()
+    elif agg == "median":
+        sec = df.groupby("second")[price_col].median().rename("price").reset_index()
+    else:
+        raise ValueError("Unsupported agg; use 'last' | 'vwap' | 'median'")
+
+    sec = sec.rename(columns={"second": "timestamp"})
+    sec["timestamp"] = pd.to_datetime(sec["timestamp"], utc=True)
+    return sec[["timestamp", "price"]]
+


### PR DESCRIPTION
Add NASDAQ ITCH ingestion and a CLI to compare simulated execution prices against ITCH data at 1-second resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e88e2e4-c08c-426c-9a46-136fb55c905f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e88e2e4-c08c-426c-9a46-136fb55c905f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

